### PR TITLE
v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.2.0
+
+### Highlights
+
+- **Simpler build**: consolidated native build into one script; removed configure “stamp”.
+- **Assets bundled by default**: dictionary + Mei voice now bundled into `priv/` unless opted out.
+- **Wider platform support**: host builds verified on Linux x86_64, Linux aarch64, and macOS 14 (arm64).
+- **Cross-compile**: tested `MIX_TARGET=rpi4` (aarch64/Nerves).
+- **Better triplet detection**: inject modern `config.sub/config.guess` to fix errors like
+  `arm64-apple-darwin… not recognized`.
+
+### Breaking / Migration
+
+- Env vars renamed:
+  - `FULL_STATIC` → `OPENJTALK_FULL_STATIC`
+  - `BUNDLE_ASSETS` → `OPENJTALK_BUNDLE_ASSETS`
+- If you previously relied on assets **not** being bundled, set `OPENJTALK_BUNDLE_ASSETS=0`.
+
 ## v0.1.0
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the dependency to your `mix.exs`:
 ```elixir
 def deps do
   [
-    {:open_jtalk_elixir, "~> 0.1.0"}
+    {:open_jtalk_elixir, "~> 0.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule OpenJtalkElixir.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
   @source_url "https://github.com/mnishiguchi/open_jtalk_elixir"
 
   def project do


### PR DESCRIPTION
### Highlights

- **Simpler build**: consolidated native build into one script; removed configure “stamp”.
- **Assets bundled by default**: dictionary + Mei voice now bundled into `priv/` unless opted out.
- **Wider platform support**: host builds verified on Linux x86_64, Linux aarch64, and macOS 14 (arm64).
- **Cross-compile**: tested `MIX_TARGET=rpi4` (aarch64/Nerves).
- **Better triplet detection**: inject modern `config.sub/config.guess` to fix errors like
  `arm64-apple-darwin… not recognized`.

### Breaking / Migration

- Env vars renamed:
  - `FULL_STATIC` → `OPENJTALK_FULL_STATIC`
  - `BUNDLE_ASSETS` → `OPENJTALK_BUNDLE_ASSETS`
- If you previously relied on assets **not** being bundled, set `OPENJTALK_BUNDLE_ASSETS=0`.