### PR TITLE
Fix WAV chunk padding handling

### DIFF
--- a/lib/open_jtalk/wav.ex
+++ b/lib/open_jtalk/wav.ex
@@ -96,13 +96,13 @@ defmodule OpenJTalk.Wav do
   # Chunk scanner: find "fmt " and "data" (ignores others).
   defp scan_chunks(<<"fmt ", size::little-32, body::binary-size(size), rest::binary>>, acc, data) do
     case parse_format(body) do
-      {:ok, format} -> scan_chunks(rest, Map.put(acc, :format, format), data)
+      {:ok, format} -> scan_chunks(skip_padding(rest, size), Map.put(acc, :format, format), data)
       {:error, _} = e -> e
     end
   end
 
   defp scan_chunks(<<"data", size::little-32, body::binary-size(size), rest::binary>>, acc, nil) do
-    scan_chunks(rest, acc, body)
+    scan_chunks(skip_padding(rest, size), acc, body)
   end
 
   # skip any other chunk
@@ -111,12 +111,15 @@ defmodule OpenJTalk.Wav do
          acc,
          data
        ),
-       do: scan_chunks(rest, acc, data)
+       do: scan_chunks(skip_padding(rest, size), acc, data)
 
   defp scan_chunks(<<>>, %{format: format}, data) when is_map(format) and is_binary(data),
     do: {:ok, format, data}
 
   defp scan_chunks(<<>>, _acc, _data), do: {:error, :missing_format_or_data}
+
+  defp skip_padding(<<_padding, rest::binary>>, size) when rem(size, 2) == 1, do: rest
+  defp skip_padding(rest, _size), do: rest
 
   defp parse_format(<<
          audio_format::little-16,
@@ -218,22 +221,27 @@ defmodule OpenJTalk.Wav do
   defp build_wav(format, data_iodata) do
     data_size = IO.iodata_length(data_iodata)
     format_chunk = encode_format(format)
-    riff_size = 4 + (8 + byte_size(format_chunk)) + (8 + data_size)
+    format_size = byte_size(format_chunk)
+    riff_size = 4 + padded_chunk_size(format_size) + padded_chunk_size(data_size)
 
     iodata = [
       "RIFF",
       <<riff_size::little-32>>,
       "WAVE",
       "fmt ",
-      <<byte_size(format_chunk)::little-32>>,
+      <<format_size::little-32>>,
       format_chunk,
+      chunk_padding(format_size),
       "data",
       <<data_size::little-32>>,
-      data_iodata
+      data_iodata,
+      chunk_padding(data_size)
     ]
 
     IO.iodata_to_binary(iodata)
   end
+
+  defp padded_chunk_size(size), do: 8 + size + padding_size(size)
 
   defp encode_format(%{
          audio_format: audio_format,
@@ -261,4 +269,10 @@ defmodule OpenJTalk.Wav do
         <<base::binary, byte_size(extra)::little-16, extra::binary>>
     end
   end
+
+  defp chunk_padding(size) when rem(size, 2) == 1, do: <<0>>
+  defp chunk_padding(_size), do: <<>>
+
+  defp padding_size(size) when rem(size, 2) == 1, do: 1
+  defp padding_size(_size), do: 0
 end

--- a/test/open_jtalk/wav_test.exs
+++ b/test/open_jtalk/wav_test.exs
@@ -3,6 +3,24 @@ defmodule OpenJTalk.WavTest do
 
   @moduletag :tmp_dir
 
+  test "parse/1 skips padding after an odd-sized ignored chunk" do
+    wav = pcm_wav(<<1, 2>>, chunks_before_fmt: [chunk("JUNK", <<255>>)])
+
+    assert {:ok, parsed} = OpenJTalk.Wav.parse(wav)
+    assert parsed.data == <<1, 2>>
+  end
+
+  test "concat_binaries/1 pads odd-sized output so it parses cleanly" do
+    first = pcm_wav(<<1>>)
+    second = pcm_wav(<<2, 3>>)
+
+    assert {:ok, merged} = OpenJTalk.Wav.concat_binaries([first, second])
+    assert {:ok, parsed} = OpenJTalk.Wav.parse(merged)
+    assert parsed.data == <<1, 2, 3>>
+    assert riff_size(merged) + 8 == byte_size(merged)
+    assert :binary.last(merged) == 0
+  end
+
   defp mk_wav!(text) do
     {:ok, wav} = OpenJTalk.to_wav_binary(text)
     wav
@@ -105,4 +123,35 @@ defmodule OpenJTalk.WavTest do
     <<"RIFF", riff_size::little-32, "WAVE", "fmt ", fsize::little-32, new_fmt::binary,
       rest::binary>>
   end
+
+  defp pcm_wav(data, opts \\ []) do
+    sample_rate = Keyword.get(opts, :sample_rate, 16_000)
+    bits_per_sample = Keyword.get(opts, :bits_per_sample, 8)
+    channels = Keyword.get(opts, :channels, 1)
+    block_align = div(channels * bits_per_sample, 8)
+    byte_rate = sample_rate * block_align
+
+    fmt_body =
+      <<1::little-16, channels::little-16, sample_rate::little-32, byte_rate::little-32,
+        block_align::little-16, bits_per_sample::little-16>>
+
+    body = [
+      "WAVE",
+      Keyword.get(opts, :chunks_before_fmt, []),
+      chunk("fmt ", fmt_body),
+      chunk("data", data)
+    ]
+
+    ["RIFF", <<IO.iodata_length(body)::little-32>>, body]
+    |> IO.iodata_to_binary()
+  end
+
+  defp chunk(id, body) when byte_size(id) == 4 and is_binary(body) do
+    [id, <<byte_size(body)::little-32>>, body, padding(body)]
+  end
+
+  defp padding(body) when rem(byte_size(body), 2) == 1, do: <<0>>
+  defp padding(_body), do: <<>>
+
+  defp riff_size(<<"RIFF", size::little-32, _rest::binary>>), do: size
 end


### PR DESCRIPTION
## Summary

Fix WAV parsing and concatenation for odd-sized RIFF chunks.

RIFF/WAV chunks are word-aligned, so odd-sized chunks may include one padding byte. Without skipping or writing that padding, parsing can become misaligned and generated WAV output can be malformed.

## Changes

* Skip padding after odd-sized `fmt `, `data`, and ignored chunks
* Add padding when concatenated WAV output has odd-sized data
* Add focused tests for odd-sized chunks and RIFF size consistency

## Verification

* `mix test`
* Confirmed manually in `iex -S mix` with `OpenJTalk.say("元氣ですかあ 、元氣が有れば、なんでもできる")`